### PR TITLE
use store_true pattern instead of type=bool

### DIFF
--- a/typress/__main__.py
+++ b/typress/__main__.py
@@ -78,9 +78,8 @@ if __name__ == "__main__":
         "-c",
         "--continuous",
         dest="continuous",
-        type=bool,
+        action="store_true",
         help="Whether to predict continuously",
-        default=True,
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Hi I just notices a small issue with the CLI: Using `parser.add_argument('--foo', default=False, type=bool)` only matches an empty string for `False`. Using the `action="store_true"`pattern makes `-c`a proper flag. This changes the default behavior to noncontinuous but that fits the CLI use case better in my opinion.

– Hendrik